### PR TITLE
[tanghaibao] Add support for CrossRate in models

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,9 +434,10 @@ Alas you still have to implement the `Genome` interface. You can however provide
 type Vector []float64
 
 func (X Vector) Crossover(Y gago.Genome, rng *rand.Rand) (gago.Genome, gago.Genome) {
-    return X, Y.(Vector)
 }
 ```
+
+Or you can set `CrossRate: 0` when initializing the GA model.
 
 
 **Why aren't my `Mutate` and `Crossover` methods modifying my `Genome`s?**

--- a/presets.go
+++ b/presets.go
@@ -10,7 +10,8 @@ func Generational(NewGenome NewGenome) GA {
 			Selector: SelTournament{
 				NContestants: 3,
 			},
-			MutRate: 0.5,
+			MutRate:   0.5,
+			CrossRate: 0.7,
 		},
 	}
 }


### PR DESCRIPTION
@MaxHalford 
Thanks for the awesome package - I'm adding support to specify crossover rate. Naturally, the `MutRate` controls how fast one explore new solutions; `CrossRate` controls how much mixing amongst good solutions. 

The old behavior was essentially `CrossRate = 1`, which, for most applications is too much. One could see this pathological behavior in the example of `grid_tsp.go`, where it seems to lack the ability to mutate (since crossover is dominating). 

This PR allows one to specify `CrossRate` inside the model.

Haibao