### PR TITLE
Fix inverted `divides`

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ With gago it's possible to use speciation on top of all the rest. To do so the `
 
 Multi-populations GAs run independent populations in parallel. They are not frequently used, however they are very easy to understand and to implement. In gago a `GA` struct contains a `Populations` field which contains each population. The number of populations is specified in the `GA`'s `NPops` field.
 
-If `Migrator` and `MigFrequency` are not provided the populations will be run independently, in parallel. However, if they are provided then at each generation number that divides `MigFrequency` (for example 5 divides 25) individuals will be exchanged between the populations following the `Migrator` protocol.
+If `Migrator` and `MigFrequency` are not provided the populations will be run independently, in parallel. However, if they are provided then at each generation number that is divisible by `MigFrequency` (for example 5 divides generation number 25) individuals will be exchanged between the populations following the `Migrator` protocol.
 
 Using multi-populations can be an easy way to gain in diversity. Moreover, not using multi-populations on a multi-core architecture is a waste of resources.
 


### PR DESCRIPTION
I think this is what you intended to mean? i.e. that migration will occur every MigFrequency generations?

Before it would mean that migration would occur on the divisors of the frequency e.g. MigFrequency=12 would migrate on generations 1,2,3,4,6,12 and then never again.